### PR TITLE
FIX: Regression in tag routes

### DIFF
--- a/javascripts/discourse/components/subcategory-list.js
+++ b/javascripts/discourse/components/subcategory-list.js
@@ -9,7 +9,7 @@ export default class SubcategoryList extends GlimmerComponent {
   get shouldShowBlock() {
     const currentRoute = this.router.currentRoute;
 
-    if (currentRoute.attributes?.category === undefined) {
+    if (!currentRoute.attributes?.category) {
       return false;
     }
 
@@ -19,6 +19,8 @@ export default class SubcategoryList extends GlimmerComponent {
     if (category.subcategories && this.shouldDisplay(category.id)) {
       return true;
     }
+
+    return false;
   }
 
   shouldDisplay(parentCategoryId) {

--- a/test/acceptance/subcategory-list-test.js
+++ b/test/acceptance/subcategory-list-test.js
@@ -30,4 +30,11 @@ acceptance("Right Sidebar - Subcategory List", function (needs) {
       "subcategory-list has at least one visible item"
     );
   });
+
+  test("Viewing a tag route works fine", async function (assert) {
+    await visit("/tag/important");
+
+    // just check that no errors are raised in other routes
+    assert.ok(visible(".topic-list-body"), "main topic list is present");
+  });
 });


### PR DESCRIPTION
The tag routes had an empty topic list, caused by the category parameter in tag routes being `null` (and not `undefined`).