### PR TITLE
DEV: Update components to use @glimmer/component

### DIFF
--- a/javascripts/discourse/components/category-topics.js
+++ b/javascripts/discourse/components/category-topics.js
@@ -1,9 +1,9 @@
 import Category from "discourse/models/category";
 import getURL from "discourse-common/lib/get-url";
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 
-export default class CategoryTopics extends GlimmerComponent {
+export default class CategoryTopics extends Component {
   @tracked topics = null;
   @tracked category = null;
 

--- a/javascripts/discourse/components/popular-tags.js
+++ b/javascripts/discourse/components/popular-tags.js
@@ -1,17 +1,15 @@
-import GlimmerComponent from "discourse/components/glimmer";
-import { getOwner } from "discourse-common/lib/get-owner";
+import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
+import { inject as service } from "@ember/service";
 
-export default class PopularTags extends GlimmerComponent {
+export default class PopularTags extends Component {
+  @service site;
   @tracked topTags = null;
 
   constructor() {
     super(...arguments);
     const count = this.args?.params?.count || 10;
-
-    this.topTags = (
-      getOwner(this).lookup("site:main").get("top_tags") || []
-    ).slice(0, count);
+    this.topTags = (this.site.get("top_tags") || []).slice(0, count);
   }
 
   willDestroy() {

--- a/javascripts/discourse/components/recent-replies.js
+++ b/javascripts/discourse/components/recent-replies.js
@@ -1,4 +1,4 @@
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 import { ajax } from "discourse/lib/ajax";
 import { tracked } from "@glimmer/tracking";
 
@@ -7,7 +7,7 @@ function stripHtml(html) {
   return doc.body.textContent || "";
 }
 
-export default class RecentReplies extends GlimmerComponent {
+export default class RecentReplies extends Component {
   @tracked replies = null;
 
   constructor() {

--- a/javascripts/discourse/components/right-sidebar-blocks.js
+++ b/javascripts/discourse/components/right-sidebar-blocks.js
@@ -1,8 +1,8 @@
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 import { getOwner } from "@ember/application";
 import { tracked } from "@glimmer/tracking";
 
-export default class RightSidebarBlocks extends GlimmerComponent {
+export default class RightSidebarBlocks extends Component {
   @tracked blocks = [];
 
   constructor() {

--- a/javascripts/discourse/components/subcategory-list.js
+++ b/javascripts/discourse/components/subcategory-list.js
@@ -1,8 +1,8 @@
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { inject as service } from "@ember/service";
 
-export default class SubcategoryList extends GlimmerComponent {
+export default class SubcategoryList extends Component {
   @service router;
   @tracked parentCategory = null;
 

--- a/javascripts/discourse/components/top-contributors.js
+++ b/javascripts/discourse/components/top-contributors.js
@@ -1,8 +1,8 @@
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 import { ajax } from "discourse/lib/ajax";
 import { tracked } from "@glimmer/tracking";
 
-export default class TopContributors extends GlimmerComponent {
+export default class TopContributors extends Component {
   @tracked topContributors = null;
 
   constructor() {


### PR DESCRIPTION
Now that all of our singletons have been converted to true Ember Services, we can remove our custom discourse/component/glimmer superclass and use explicit injection where needed.