### PR TITLE
FEATURE: scope to category + exclude tags

### DIFF
--- a/javascripts/discourse/components/popular-tags.js
+++ b/javascripts/discourse/components/popular-tags.js
@@ -9,8 +9,8 @@ export default class PopularTags extends Component {
   constructor() {
     super(...arguments);
     const count = this.args?.params?.count || 10;
-    const excludedTags = this.args?.params?.excluded_tags || [];
-    const scopeToCategory = this.args?.params?.scope_to_category || false;
+    const excludedTags = this.args?.params?.excludedTags || [];
+    const scopeToCategory = this.args?.params?.scopeToCategory || false;
     const tags = scopeToCategory
       ? this.site.category_top_tags
       : this.site.top_tags;

--- a/javascripts/discourse/components/popular-tags.js
+++ b/javascripts/discourse/components/popular-tags.js
@@ -8,8 +8,25 @@ export default class PopularTags extends Component {
 
   constructor() {
     super(...arguments);
-    const count = this.args?.params?.count || 10;
-    this.topTags = (this.site.get("top_tags") || []).slice(0, count);
+    const count = settings.popular_tags_limit;
+    let tags;
+    const excludedTags = settings.excluded_tags;
+
+    if (settings.scope_to_category) {
+      tags = this.site.category_top_tags;
+    } else {
+      tags = this.site.get("top_tags");
+    }
+
+    if (excludedTags.length !== 0) {
+      this.topTags = tags
+        .filter((tag) => {
+          return excludedTags.indexOf(tag) === -1;
+        })
+        .slice(0, count);
+    } else {
+      this.topTags = (tags || []).slice(0, count);
+    }
   }
 
   willDestroy() {

--- a/javascripts/discourse/components/popular-tags.js
+++ b/javascripts/discourse/components/popular-tags.js
@@ -8,11 +8,12 @@ export default class PopularTags extends Component {
 
   constructor() {
     super(...arguments);
-    const count = settings.popular_tags_limit;
+    const count = this.args?.params?.count || 10;
     let tags;
-    const excludedTags = settings.excluded_tags;
+    const excludedTags = this.args?.params?.excluded_tags || [];
+    const scope_to_category = this.args?.params?.scope_to_category || false;
 
-    if (settings.scope_to_category) {
+    if (scope_to_category) {
       tags = this.site.category_top_tags;
     } else {
       tags = this.site.get("top_tags");

--- a/javascripts/discourse/components/popular-tags.js
+++ b/javascripts/discourse/components/popular-tags.js
@@ -11,9 +11,9 @@ export default class PopularTags extends Component {
     const count = this.args?.params?.count || 10;
     let tags;
     const excludedTags = this.args?.params?.excluded_tags || [];
-    const scope_to_category = this.args?.params?.scope_to_category || false;
+    const scopeToCategory = this.args?.params?.scope_to_category || false;
 
-    if (scope_to_category) {
+    if (scopeToCategory) {
       tags = this.site.category_top_tags;
     } else {
       tags = this.site.get("top_tags");

--- a/settings.yml
+++ b/settings.yml
@@ -29,9 +29,20 @@ blocks:
         }
       }
     }
+scope_to_category:
+  type: bool
+  default: false
+  description: "Checking this box will scope the tags to the category. Leaving this unchecked (default) will show all tags across all categories."
+popular_tags_limit:
+  type: integer
+  default: 10
+  description: "The maximum amount of popular tags that will be shown."
+excluded_tags:
+  default: ""
+  description: "A comma separated list of tagnames that should be excluded from the popular tags component."
 show_in_routes:
   type: list
-  list_type: 'simple'
+  list_type: "simple"
   default: ""
   description: "Advanced users only: limit sidebar to the selected routes. When empty, the sidebar is shown on all topic list routes. <br/><br/>Examples: discovery.latest, discovery.unread, discovery.new, discovery.top, tag.show"
   allow_any: true

--- a/settings.yml
+++ b/settings.yml
@@ -29,17 +29,6 @@ blocks:
         }
       }
     }
-scope_to_category:
-  type: bool
-  default: false
-  description: "Checking this box will scope the tags to the category. Leaving this unchecked (default) will show all tags across all categories."
-popular_tags_limit:
-  type: integer
-  default: 10
-  description: "The maximum amount of popular tags that will be shown."
-excluded_tags:
-  default: ""
-  description: "A comma separated list of tagnames that should be excluded from the popular tags component."
 show_in_routes:
   type: list
   list_type: "simple"


### PR DESCRIPTION
Since both these features are used/needed for Quicksight, I added both.
- get limit from settings
- option to exclude certain tags
- option to scope to category