### PR TITLE
FEATURE: Allow showing sidebar in specific category/tag routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Adds ability to display a right-sided sidebar to topic list routes. There are two settings included:
 
 - `blocks`: choose the blocks to display and adjust their ordering
-- `show_in_routes`: decide which routes to display the sidebar (by default, it will show on all discovery routes except for `/categories`)
+- `show_in_routes`: decide which routes to display the sidebar (by default, it will show on all lists except for `/categories`)
 
 ### Included blocks
 

--- a/javascripts/connectors/before-list-area/tc-right-sidebar.js
+++ b/javascripts/connectors/before-list-area/tc-right-sidebar.js
@@ -6,15 +6,28 @@ export default {
     this.reopen({
       router: service(),
 
-      @discourseComputed("router.currentRouteName")
-      showSidebar(currentRouteName) {
+      @discourseComputed(
+        "router.currentRouteName",
+        "router.currentRoute.attributes.category.slug",
+        "router.currentRoute.attributes.tag.id"
+      )
+      showSidebar(currentRouteName, categorySlug, tagId) {
         if (this.site.mobileView) {
           return false;
         }
 
         if (settings.show_in_routes !== "") {
           const selectedRoutes = settings.show_in_routes.split("|");
-          return selectedRoutes.includes(currentRouteName) ? true : false;
+
+          if (
+            selectedRoutes.includes(currentRouteName) ||
+            selectedRoutes.includes(`c/${categorySlug}`) ||
+            selectedRoutes.includes(`tag/${tagId}`)
+          ) {
+            return true;
+          } else {
+            return false;
+          }
         }
 
         // if theme setting is empty, show everywhere except /categories

--- a/settings.yml
+++ b/settings.yml
@@ -33,6 +33,6 @@ show_in_routes:
   type: list
   list_type: "simple"
   default: ""
-  description: "Advanced users only: limit sidebar to the selected routes. When empty, the sidebar is shown on all topic list routes. <br/><br/>Examples: discovery.latest, discovery.unread, discovery.new, discovery.top, tag.show"
+  description: "Advanced users only: limit sidebar to the selected routes. <br/><br/>Examples: discovery.latest, discovery.unread, discovery.new, discovery.top, tag.show, \"c/category-slug\" (for categories), \"tag/sample-tag\" (for tags). <br/><br/>When empty, the sidebar is shown on all list routes."
   allow_any: true
   choices:

--- a/test/acceptance/right-sidebar-test.js
+++ b/test/acceptance/right-sidebar-test.js
@@ -1,6 +1,8 @@
 import { acceptance, visible } from "discourse/tests/helpers/qunit-helpers";
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
+import discoveryFixture from "discourse/tests/fixtures/discovery-fixtures";
+import { cloneJSON } from "discourse-common/lib/object";
 
 acceptance("Right Sidebar", function () {
   test("Viewing latest", async function (assert) {
@@ -20,12 +22,29 @@ acceptance("Right Sidebar", function () {
 });
 
 acceptance("Right Sidebar - custom routes", function (needs) {
+  needs.settings({ tagging_enabled: true });
+
   needs.hooks.beforeEach(() => {
-    settings.show_in_routes = "discovery.categories|discovery.top";
+    settings.show_in_routes =
+      "discovery.categories|discovery.top|c/bug|tag/important";
   });
 
   needs.hooks.afterEach(() => {
     settings.blocks = "[]";
+  });
+
+  needs.pretender((server, helper) => {
+    server.get(`/c/bug/1/l/latest.json`, () => {
+      return helper.response(
+        cloneJSON(discoveryFixture["/c/bug/1/l/latest.json"])
+      );
+    });
+
+    server.get(`/tag/important/l/latest.json`, () => {
+      return helper.response(
+        cloneJSON(discoveryFixture["/tag/important/l/latest.json"])
+      );
+    });
   });
 
   test("Viewing latest", async function (assert) {
@@ -48,10 +67,26 @@ acceptance("Right Sidebar - custom routes", function (needs) {
 
   test("Viewing top", async function (assert) {
     await visit("/top");
-
     assert.ok(
       visible(".tc-right-sidebar"),
       "sidebar present under /top due to theme setting"
+    );
+  });
+
+  test("Viewing the bug category", async function (assert) {
+    await visit("/c/bug/l/latest");
+    assert.ok(
+      visible(".tc-right-sidebar"),
+      "sidebar present under the bug category"
+    );
+  });
+
+  test("Viewing the important tag", async function (assert) {
+    await visit("/tag/important");
+
+    assert.ok(
+      visible(".tc-right-sidebar"),
+      "sidebar present under the important tag"
     );
   });
 });


### PR DESCRIPTION
Admins can now decide to specifically pick the tag or category routes the sidebar should be displayed on.

<img width="815" alt="image" src="https://user-images.githubusercontent.com/368961/225434556-e0554bf9-4e0e-4959-b6de-a178193e184d.png">
