### PR TITLE
FIX: ensures tags is an array

### DIFF
--- a/javascripts/discourse/components/popular-tags.js
+++ b/javascripts/discourse/components/popular-tags.js
@@ -13,7 +13,7 @@ export default class PopularTags extends Component {
     const excludedTags = this.args?.params?.excludedTags || [];
     const scopeToCategory = this.args?.params?.scopeToCategory || false;
     const tags =
-      (scopeToCategory ? this.site.category_top_tags : this.site.top_tags) ??
+      (scopeToCategory ? this.site.category_top_tags : this.site.top_tags) ||
       [];
     const category = currentRoute.attributes?.category;
 

--- a/javascripts/discourse/components/popular-tags.js
+++ b/javascripts/discourse/components/popular-tags.js
@@ -12,9 +12,9 @@ export default class PopularTags extends Component {
     const count = this.args?.params?.count || 10;
     const excludedTags = this.args?.params?.excludedTags || [];
     const scopeToCategory = this.args?.params?.scopeToCategory || false;
-    const tags = scopeToCategory
-      ? this.site.category_top_tags
-      : this.site.top_tags;
+    const tags =
+      (scopeToCategory ? this.site.category_top_tags : this.site.top_tags) ??
+      [];
     const category = currentRoute.attributes?.category;
 
     if (excludedTags.length !== 0) {


### PR DESCRIPTION
If the site had no tags it would fail while trying to iterate over them.