### PR TITLE
UX: Use full name over username for top contributors if it exists

### DIFF
--- a/javascripts/discourse/templates/components/top-contributors.hbs
+++ b/javascripts/discourse/templates/components/top-contributors.hbs
@@ -10,7 +10,9 @@
         class="top-contributors--user-badge"
       >
         {{avatar item.user imageSize="small"}}
-        {{#if (and item.user.name siteSettings.prioritize_username_in_ux)}}
+        {{#if siteSettings.prioritize_username_in_ux}}
+          {{item.user.username}}
+        {{else if item.user.name}}
           {{item.user.name}}
         {{else}}
           {{item.user.username}}
@@ -29,9 +31,6 @@
   {{/each}}
 </div>
 
-<a
-  class="top-contributors--view-all"
-  href={{this.viewAllUrl}}
->
+<a class="top-contributors--view-all" href={{this.viewAllUrl}}>
   {{theme-i18n "top_contributors.view_all"}}
 </a>

--- a/javascripts/discourse/templates/components/top-contributors.hbs
+++ b/javascripts/discourse/templates/components/top-contributors.hbs
@@ -10,7 +10,11 @@
         class="top-contributors--user-badge"
       >
         {{avatar item.user imageSize="small"}}
-        {{html-safe item.user.username}}
+        {{#if item.user.name}}
+          {{html-safe item.user.name}}
+        {{else}}
+          {{html-safe item.user.username}}
+        {{/if}}
       </span>
       <span class={{concat "top-contributors--user-likes order--" this.order}}>
         {{#if (eq this.order "likes_received")}}

--- a/javascripts/discourse/templates/components/top-contributors.hbs
+++ b/javascripts/discourse/templates/components/top-contributors.hbs
@@ -10,10 +10,10 @@
         class="top-contributors--user-badge"
       >
         {{avatar item.user imageSize="small"}}
-        {{#if (and item.user.name siteSettings.enable_names)}}
-          {{html-safe item.user.name}}
+        {{#if (and item.user.name siteSettings.prioritize_username_in_ux)}}
+          {{item.user.name}}
         {{else}}
-          {{html-safe item.user.username}}
+          {{item.user.username}}
         {{/if}}
       </span>
       <span class={{concat "top-contributors--user-likes order--" this.order}}>

--- a/javascripts/discourse/templates/components/top-contributors.hbs
+++ b/javascripts/discourse/templates/components/top-contributors.hbs
@@ -10,7 +10,7 @@
         class="top-contributors--user-badge"
       >
         {{avatar item.user imageSize="small"}}
-        {{#if item.user.name}}
+        {{#if (and item.user.name siteSettings.enable_names)}}
           {{html-safe item.user.name}}
         {{else}}
           {{html-safe item.user.username}}


### PR DESCRIPTION
Request to have Top Contributors within this component match [Top Contributors Sidebar](https://github.com/discourse/discourse-top-contributors-sidebar).