### PR TITLE
FEATURE: Support subcategory paths in custom route setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ You can control some features for the provided blocks via parameters.
 | excludedGroupNames          | Excludes specified groups             |            | Group names                                      | top-contributors                 |
 | order                       | Orders the contributors               | likes_received | String (likes_received or likes_given)       | top-contributors                 |
 | period                      | Time period for top contributors      | yearly         | all, yearly, quarterly, monthly, weekly, daily   | top-contributors                 |
+
+### Blocks from other plugins
+
+The Discourse Calendar plugin comes with a block called `upcoming-events-list` that you can use in conjunction with this component. You'll want to ensure the desired route is enabled via the `events calendar categories` setting in the Calendar plugin settings. The block params use this [syntax](https://momentjs.com/docs/#/displaying/format/), for example `MMMM D, YYYY`.

--- a/about.json
+++ b/about.json
@@ -5,7 +5,7 @@
   "license_url": "https://github.com/discourse/discourse-right-sidebar-blocks/blob/main/LICENSE",
   "about_url": "https://meta.discourse.org/t/right-sidebar-blocks/231067",
   "learn_more": "TODO",
-  "theme_version": "0.0.1",
+  "theme_version": "0.0.2",
   "minimum_discourse_version": null,
   "maximum_discourse_version": null,
   "assets": {},

--- a/javascripts/connectors/before-list-area/tc-right-sidebar.js
+++ b/javascripts/connectors/before-list-area/tc-right-sidebar.js
@@ -6,23 +6,61 @@ export default {
     this.reopen({
       router: service(),
 
+      // @discourseComputed(
+      //   "router.currentRouteName",
+      //   "router.currentRoute.attributes.category.slug",
+      //   "router.currentRoute.attributes.tag.id"
+      // )
+      // showSidebar(currentRouteName, categorySlug, tagId) {
+      //   if (this.site.mobileView) {
+      //     return false;
+      //   }
+
+      //   if (settings.show_in_routes !== "") {
+      //     const selectedRoutes = settings.show_in_routes.split("|");
+
+      //     if (
+      //       selectedRoutes.includes(currentRouteName) ||
+      //       selectedRoutes.includes(`c/${categorySlug}`) ||
+      //       selectedRoutes.includes(`tag/${tagId}`)
+      //     ) {
+      //       return true;
+      //     } else {
+      //       return false;
+      //     }
+      //   }
+
+      //   // if theme setting is empty, show everywhere except /categories
+      //   return currentRouteName === "discovery.categories" ? false : true;
+      // }
+
       @discourseComputed(
         "router.currentRouteName",
-        "router.currentRoute.attributes.category.slug",
-        "router.currentRoute.attributes.tag.id"
+        "router.currentRoute.attributes.category"
       )
-      showSidebar(currentRouteName, categorySlug, tagId) {
+      showSidebar(currentRouteName, category) {
         if (this.site.mobileView) {
           return false;
         }
 
         if (settings.show_in_routes !== "") {
           const selectedRoutes = settings.show_in_routes.split("|");
+          let subcategory = null;
+          let parentCategory = null;
+
+        // check if current page is subcategory
+          // -- is category
+          // -- does not have children itself
+          // -- has a parent category
+          if (!!this.category &&
+            !this.category.has_children &&
+            !!this.category.parent_category_id) {
+            subcategory = this.category.slug;
+            parentCategory = category.ancestors[0].slug
+          }
 
           if (
-            selectedRoutes.includes(currentRouteName) ||
-            selectedRoutes.includes(`c/${categorySlug}`) ||
-            selectedRoutes.includes(`tag/${tagId}`)
+            selectedRoutes.includes(`"c/${parentCategory}/${subcategory}"`)
           ) {
             return true;
           } else {

--- a/javascripts/connectors/before-list-area/tc-right-sidebar.js
+++ b/javascripts/connectors/before-list-area/tc-right-sidebar.js
@@ -30,7 +30,7 @@ export default {
             !this.category.has_children &&
             !!this.category.parent_category_id) {
             subcategory = categorySlug;
-            parentCategory = category.ancestors[0].slug
+            parentCategory = category.ancestors[0].slug;
           }
 
           if (

--- a/javascripts/connectors/before-list-area/tc-right-sidebar.js
+++ b/javascripts/connectors/before-list-area/tc-right-sidebar.js
@@ -6,39 +6,13 @@ export default {
     this.reopen({
       router: service(),
 
-      // @discourseComputed(
-      //   "router.currentRouteName",
-      //   "router.currentRoute.attributes.category.slug",
-      //   "router.currentRoute.attributes.tag.id"
-      // )
-      // showSidebar(currentRouteName, categorySlug, tagId) {
-      //   if (this.site.mobileView) {
-      //     return false;
-      //   }
-
-      //   if (settings.show_in_routes !== "") {
-      //     const selectedRoutes = settings.show_in_routes.split("|");
-
-      //     if (
-      //       selectedRoutes.includes(currentRouteName) ||
-      //       selectedRoutes.includes(`c/${categorySlug}`) ||
-      //       selectedRoutes.includes(`tag/${tagId}`)
-      //     ) {
-      //       return true;
-      //     } else {
-      //       return false;
-      //     }
-      //   }
-
-      //   // if theme setting is empty, show everywhere except /categories
-      //   return currentRouteName === "discovery.categories" ? false : true;
-      // }
-
       @discourseComputed(
         "router.currentRouteName",
-        "router.currentRoute.attributes.category"
+        "router.currentRoute.attributes.category",
+        "router.currentRoute.attributes.category.slug",
+        "router.currentRoute.attributes.tag.id"
       )
-      showSidebar(currentRouteName, category) {
+      showSidebar(currentRouteName, category, categorySlug, tagId) {
         if (this.site.mobileView) {
           return false;
         }
@@ -48,19 +22,22 @@ export default {
           let subcategory = null;
           let parentCategory = null;
 
-        // check if current page is subcategory
+          // check if current page is subcategory
           // -- is category
           // -- does not have children itself
           // -- has a parent category
           if (!!this.category &&
             !this.category.has_children &&
             !!this.category.parent_category_id) {
-            subcategory = this.category.slug;
+            subcategory = categorySlug;
             parentCategory = category.ancestors[0].slug
           }
 
           if (
-            selectedRoutes.includes(`"c/${parentCategory}/${subcategory}"`)
+            selectedRoutes.includes(currentRouteName) ||
+            selectedRoutes.includes(`c/${categorySlug}`) ||
+            selectedRoutes.includes(`c/${parentCategory}/${subcategory}`) ||
+            selectedRoutes.includes(`tag/${tagId}`)
           ) {
             return true;
           } else {
@@ -70,7 +47,7 @@ export default {
 
         // if theme setting is empty, show everywhere except /categories
         return currentRouteName === "discovery.categories" ? false : true;
-      },
+      }
     });
   },
 };

--- a/javascripts/connectors/before-list-area/tc-right-sidebar.js
+++ b/javascripts/connectors/before-list-area/tc-right-sidebar.js
@@ -26,9 +26,11 @@ export default {
           // -- is category
           // -- does not have children itself
           // -- has a parent category
-          if (!!this.category &&
+          if (
+            !!this.category &&
             !this.category.has_children &&
-            !!this.category.parent_category_id) {
+            !!this.category.parent_category_id
+          ) {
             subcategory = categorySlug;
             parentCategory = category.ancestors[0].slug;
           }
@@ -47,7 +49,7 @@ export default {
 
         // if theme setting is empty, show everywhere except /categories
         return currentRouteName === "discovery.categories" ? false : true;
-      }
+      },
     });
   },
 };

--- a/test/acceptance/right-sidebar-test.js
+++ b/test/acceptance/right-sidebar-test.js
@@ -57,7 +57,6 @@ acceptance("Right Sidebar - custom routes", function (needs) {
     });
 
     server.get(`/c/bug/foo/2/l/latest.json`, () => {
-      console.log("PRETENDER IS WORKING")
       return helper.response(
         cloneJSON(discoveryFixture["/c/bug/1/l/latest.json"])
       );

--- a/test/acceptance/right-sidebar-test.js
+++ b/test/acceptance/right-sidebar-test.js
@@ -26,15 +26,38 @@ acceptance("Right Sidebar - custom routes", function (needs) {
 
   needs.hooks.beforeEach(() => {
     settings.show_in_routes =
-      "discovery.categories|discovery.top|c/bug|c/bar/foo|tag/important";
+      "discovery.categories|discovery.top|c/bug|c/bug/foo|tag/important";
   });
 
   needs.hooks.afterEach(() => {
     settings.blocks = "[]";
   });
 
+  needs.site({
+    categories: [
+      {
+        id: 1,
+        name: "bug",
+        slug: "bug",
+      },
+      {
+        id: 2,
+        name: "foo",
+        slug: "foo",
+        parent_category_id: 1,
+      },
+    ],
+  });
+
   needs.pretender((server, helper) => {
     server.get(`/c/bug/1/l/latest.json`, () => {
+      return helper.response(
+        cloneJSON(discoveryFixture["/c/bug/1/l/latest.json"])
+      );
+    });
+
+    server.get(`/c/bug/foo/2/l/latest.json`, () => {
+      console.log("PRETENDER IS WORKING")
       return helper.response(
         cloneJSON(discoveryFixture["/c/bug/1/l/latest.json"])
       );
@@ -82,10 +105,11 @@ acceptance("Right Sidebar - custom routes", function (needs) {
   });
 
   test("Viewing the foo subcategory", async function (assert) {
-    await visit("/c/bar/foo");
+    await visit("/c/bug/foo/2");
+
     assert.ok(
       visible(".tc-right-sidebar"),
-      "sidebar present under the foo bug subcategory"
+      "sidebar present under the foo subcategory"
     );
   });
 

--- a/test/acceptance/right-sidebar-test.js
+++ b/test/acceptance/right-sidebar-test.js
@@ -81,6 +81,14 @@ acceptance("Right Sidebar - custom routes", function (needs) {
     );
   });
 
+  test("Viewing the urgent bug subcategory", async function (assert) {
+    await visit("/c/bug/urgent");
+    assert.ok(
+      visible(".tc-right-sidebar"),
+      "sidebar present under the urgent bug subcategory"
+    );
+  });
+
   test("Viewing the important tag", async function (assert) {
     await visit("/tag/important");
 

--- a/test/acceptance/right-sidebar-test.js
+++ b/test/acceptance/right-sidebar-test.js
@@ -26,7 +26,7 @@ acceptance("Right Sidebar - custom routes", function (needs) {
 
   needs.hooks.beforeEach(() => {
     settings.show_in_routes =
-      "discovery.categories|discovery.top|c/bug|tag/important";
+      "discovery.categories|discovery.top|c/bug|c/bar/foo|tag/important";
   });
 
   needs.hooks.afterEach(() => {
@@ -81,11 +81,11 @@ acceptance("Right Sidebar - custom routes", function (needs) {
     );
   });
 
-  test("Viewing the urgent bug subcategory", async function (assert) {
-    await visit("/c/bug/urgent");
+  test("Viewing the foo subcategory", async function (assert) {
+    await visit("/c/bar/foo");
     assert.ok(
       visible(".tc-right-sidebar"),
-      "sidebar present under the urgent bug subcategory"
+      "sidebar present under the foo bug subcategory"
     );
   });
 


### PR DESCRIPTION
Allows component to handle subcategories.

![Screenshot 2024-08-07 at 5 16 01 PM](https://github.com/user-attachments/assets/779b0937-f97a-41a5-90c6-71a75ad8952d)

In order for this to work with `upcoming-events-list`, you must add the subcategory to the Calendar plugin settings:
![Screenshot 2024-08-07 at 5 16 30 PM](https://github.com/user-attachments/assets/14e35831-4c18-4d05-99d7-d45bd41b3157)

(This started as a Sailpoint request, and from what I've seen on Meta it looks like others might utilize this as well.)