### PR TITLE
UX: top contributors: fix wrapping with long numbers and alignment

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -48,6 +48,7 @@
 .top-contributors--user-likes {
   grid-area: right;
   justify-self: end;
+  white-space: nowrap;
 }
 
 // Recent replies

--- a/javascripts/discourse/components/top-contributors.hbs
+++ b/javascripts/discourse/components/top-contributors.hbs
@@ -20,7 +20,7 @@
       </span>
       <span class={{concat "top-contributors--user-likes order--" this.order}}>
         {{#if (eq this.order "likes_received")}}
-          {{number 56178}}
+          {{number item.likes_received}}
           {{d-icon "heart"}}
         {{else}}
           {{number item.likes_given}}

--- a/javascripts/discourse/components/top-contributors.hbs
+++ b/javascripts/discourse/components/top-contributors.hbs
@@ -20,11 +20,11 @@
       </span>
       <span class={{concat "top-contributors--user-likes order--" this.order}}>
         {{#if (eq this.order "likes_received")}}
-          {{d-icon "heart"}}
           {{item.likes_received}}
-        {{else}}
           {{d-icon "heart"}}
+        {{else}}
           {{item.likes_given}}
+          {{d-icon "heart"}}
         {{/if}}
       </span>
     </div>

--- a/javascripts/discourse/components/top-contributors.hbs
+++ b/javascripts/discourse/components/top-contributors.hbs
@@ -20,10 +20,10 @@
       </span>
       <span class={{concat "top-contributors--user-likes order--" this.order}}>
         {{#if (eq this.order "likes_received")}}
-          {{item.likes_received}}
+          {{number 56178}}
           {{d-icon "heart"}}
         {{else}}
-          {{item.likes_given}}
+          {{number item.likes_given}}
           {{d-icon "heart"}}
         {{/if}}
       </span>


### PR DESCRIPTION
Added a `no-wrap` to avoid longer numbers creating a double line, and switched the order so the heart is aligned to the right, which looks visually nicer with numbers of varying length. 

| Before | After |
|--------|--------|
| ![CleanShot 2025-04-16 at 15 16 30@2x](https://github.com/user-attachments/assets/949a13b5-878e-43b2-91b3-737feb9b3ca8) | ![CleanShot 2025-04-16 at 15 15 57@2x](https://github.com/user-attachments/assets/14d18391-69bd-48fa-8e1a-1861c3ebfdf2) | 

I've also added the `number` helper, so longer numbers revert from ie 56218 to 56.2k 
![CleanShot 2025-04-16 at 15 23 44@2x](https://github.com/user-attachments/assets/22e63dff-8fb3-49eb-95f0-03b044530751)
