### PR TITLE
UX: Fix regression with layout

### DIFF
--- a/javascripts/connectors/before-list-area/tc-right-sidebar.js
+++ b/javascripts/connectors/before-list-area/tc-right-sidebar.js
@@ -1,7 +1,9 @@
 import Component from "@ember/component";
 import { service } from "@ember/service";
+import { tagName } from "@ember-decorators/component";
 import discourseComputed from "discourse/lib/decorators";
 
+@tagName("")
 export default class TcRightSidebar extends Component {
   @service router;
   @service site;


### PR DESCRIPTION
An additional div from the last commit broke the
layout of the right sidebar.

Ideally we'd add a test here, but we don't have the right setup to test placement of an element on the page. 