### PR TITLE
FIX: Restore backwards compatibility for `@params` argument

### DIFF
--- a/javascripts/discourse/components/right-sidebar-blocks.gjs
+++ b/javascripts/discourse/components/right-sidebar-blocks.gjs
@@ -25,12 +25,17 @@ export default class RightSidebarBlocks extends Component {
 
       if (block.component) {
         block.classNames = `rs-component rs-${block.name}`;
-        block.parsedParams = {};
+
+        const parsedParams = {};
         if (block.params) {
           block.params.forEach((p) => {
-            block.parsedParams[p.name] = p.value;
+            parsedParams[p.name] = p.value;
           });
         }
+
+        // `params` key is for backwards compatibility.
+        // New components can use the top level curried arguments
+        block.parsedParams = { params: parsedParams, ...parsedParams };
 
         blocksArray.push(block);
       } else {


### PR DESCRIPTION
Followup to fd584eda648760fce7efd7e01202abda5a4a6c30