### PR TITLE
DEV: Update tag URLs to use new slug/id format

### DIFF
--- a/javascripts/discourse/components/popular-tags.gjs
+++ b/javascripts/discourse/components/popular-tags.gjs
@@ -20,24 +20,14 @@ export default class PopularTags extends Component {
     const excludedTags = this.args.excludedTags || [];
     const scopeToCategory = this.args.scopeToCategory || false;
     const tags =
-      (scopeToCategory ? this.site.category_top_tags : this.site.top_tags) ||
-      [];
+      (scopeToCategory ? this.site.categoryTopTags : this.site.topTags) || [];
     const category = currentRoute.attributes?.category;
 
-    // TODO(https://github.com/discourse/discourse/pull/36678): The string check can be
-    // removed using .discourse-compatibility once the PR is merged.
-    const normalizedTags = tags.map((tag) =>
-      typeof tag === "string" ? tag : tag.name
-    );
+    let filteredTags = tags;
     if (excludedTags.length !== 0) {
-      this.topTags = normalizedTags
-        .filter((tag) => {
-          return excludedTags.indexOf(tag) === -1;
-        })
-        .slice(0, count);
-    } else {
-      this.topTags = normalizedTags.slice(0, count);
+      filteredTags = tags.filter((tag) => !excludedTags.includes(tag.name));
     }
+    this.topTags = filteredTags.slice(0, count);
 
     if (this.topTags.length === 0) {
       return false;
@@ -70,9 +60,9 @@ export default class PopularTags extends Component {
       </h3>
 
       <div class="popular-tags__container">
-        {{#each this.topTags as |t|}}
-          <a href="/tag/{{t}}" class="popular-tags__tag">
-            {{t}}
+        {{#each this.topTags as |tag|}}
+          <a href={{tag.url}} class="popular-tags__tag">
+            {{tag.name}}
           </a>
         {{/each}}
       </div>

--- a/spec/system/page_objects/components/popular_tags.rb
+++ b/spec/system/page_objects/components/popular_tags.rb
@@ -6,7 +6,7 @@ module PageObjects
       SELECTOR = ".popular-tags__container"
 
       def has_tag_item?(tag)
-        has_css?("#{SELECTOR} .popular-tags__tag[href='/tag/#{tag.name}']", text: tag.name)
+        has_css?("#{SELECTOR} .popular-tags__tag[href='#{tag.url}']", text: tag.name)
       end
 
       def has_no_tag_item?(tag)

--- a/test/acceptance/right-sidebar-test.js
+++ b/test/acceptance/right-sidebar-test.js
@@ -60,7 +60,7 @@ acceptance("Right Sidebar - custom routes", function (needs) {
       );
     });
 
-    server.get(`/tag/important/l/latest.json`, () => {
+    server.get("/tag/1/l/latest.json", () => {
       return helper.response(
         cloneJSON(discoveryFixture["/tag/important/l/latest.json"])
       );
@@ -104,7 +104,7 @@ acceptance("Right Sidebar - custom routes", function (needs) {
   });
 
   test("Viewing the important tag", async function (assert) {
-    await visit("/tag/important");
+    await visit("/tag/important/1");
 
     assert
       .dom(".tc-right-sidebar")

--- a/test/acceptance/subcategory-list-test.js
+++ b/test/acceptance/subcategory-list-test.js
@@ -1,8 +1,17 @@
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
+import { cloneJSON } from "discourse/lib/object";
+import discoveryFixture from "discourse/tests/fixtures/discovery-fixtures";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Right Sidebar - Subcategory List", function (needs) {
+  needs.pretender((server, helper) => {
+    server.get("/tag/1/l/latest.json", () =>
+      helper.response(
+        cloneJSON(discoveryFixture["/tag/important/l/latest.json"])
+      )
+    );
+  });
   const blocksJSON = [
     {
       name: "subcategory-list",
@@ -30,7 +39,7 @@ acceptance("Right Sidebar - Subcategory List", function (needs) {
   });
 
   test("Viewing a tag route works fine", async function (assert) {
-    await visit("/tag/important");
+    await visit("/tag/important/1");
 
     // just check that no errors are raised in other routes
     assert.dom(".topic-list-body").exists("main topic list is present");


### PR DESCRIPTION
What is the problem?

Discourse core commit discourse/discourse@737577e changed tag
routes from `/tag/:name` to `/tag/:slug/:id` for browser URLs.
The `PopularTags` component was generating tag URLs using
hardcoded `/tag/{{name}}` strings, which will not match the new
canonical format.

What is the solution?

Update `PopularTags` to use `tag.url` from the `Tag` model
instances returned by `site.topTags` instead of hardcoded URL
strings. Update the page object to use `Tag#url` for assertions
and the acceptance test to use the new `/tag/:slug/:id` route
format.