### PR TITLE
FIX: popular-tags data collision with native tag dropdown

### DIFF
--- a/javascripts/discourse/components/popular-tags.gjs
+++ b/javascripts/discourse/components/popular-tags.gjs
@@ -1,24 +1,54 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
+import getURL from "discourse/lib/get-url";
 import { i18n } from "discourse-i18n";
 
 export default class PopularTags extends Component {
   @service site;
   @service router;
 
+  get excludedTags() {
+    if (!this.args.excludedTags) {
+      return [];
+    }
+
+    if (Array.isArray(this.args.excludedTags)) {
+      return this.args.excludedTags;
+    }
+
+    return this.args.excludedTags
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+  }
+
   get topTags() {
-    const excludedTags = this.args.excludedTags || [];
     const tags =
       (this.args.scopeToCategory
-        ? this.site.categoryTopTags
-        : this.site.topTags) || [];
+        ? this.site.category_top_tags
+        : this.site.top_tags) || [];
 
     let filteredTags = tags;
-    if (excludedTags.length > 0) {
-      filteredTags = tags.filter((tag) => !excludedTags.includes(tag.name));
+    if (this.excludedTags.length > 0) {
+      filteredTags = tags.filter(
+        (tag) => !this.excludedTags.includes(tag.name)
+      );
     }
 
     return filteredTags.slice(0, this.args.count || 10);
+  }
+
+  tagUrl(tag) {
+    if (tag.url) {
+      return tag.url;
+    }
+
+    if (tag.id) {
+      const slug = tag.slug || `${tag.id}-tag`;
+      return getURL(`/tag/${slug}/${tag.id}`);
+    }
+
+    return getURL(`/tag/${tag.name.replaceAll(".", "%2E")}`);
   }
 
   get shouldShowBlock() {
@@ -44,7 +74,7 @@ export default class PopularTags extends Component {
 
       <div class="popular-tags__container">
         {{#each this.topTags as |tag|}}
-          <a href={{tag.url}} class="popular-tags__tag">
+          <a href={{this.tagUrl tag}} class="popular-tags__tag">
             {{tag.name}}
           </a>
         {{/each}}

--- a/test/acceptance/right-sidebar-test.js
+++ b/test/acceptance/right-sidebar-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { cloneJSON } from "discourse/lib/object";
 import discoveryFixture from "discourse/tests/fixtures/discovery-fixtures";
@@ -16,6 +16,47 @@ acceptance("Right Sidebar", function () {
     assert
       .dom(".tc-right-sidebar")
       .doesNotExist("sidebar not present under /categories by default");
+  });
+});
+
+acceptance("Right Sidebar - popular tags", function (needs) {
+  const blocksJSON = [{ name: "popular-tags" }];
+  const topTags = [
+    { id: 1, name: "ruby", slug: "ruby" },
+    { id: 2, name: "javascript", slug: "javascript" },
+  ];
+
+  needs.settings({ tagging_enabled: true });
+
+  needs.hooks.beforeEach(function () {
+    settings.blocks = JSON.stringify(blocksJSON);
+  });
+
+  needs.hooks.afterEach(function () {
+    settings.blocks = "[]";
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/latest.json", () => {
+      const response = cloneJSON(discoveryFixture["/latest.json"]);
+      response.topic_list.top_tags = cloneJSON(topTags);
+
+      return helper.response(response);
+    });
+  });
+
+  test("does not consume native tag dropdown data", async function (assert) {
+    await visit("/");
+
+    assert
+      .dom(".popular-tags__tag[href='/tag/ruby/1']")
+      .hasText("ruby", "the sidebar displays popular tags");
+
+    await click(".tag-drop-header");
+
+    assert
+      .dom(".tag-drop .tag-row[data-name='ruby']")
+      .hasText("ruby", "the native tag dropdown still displays tag rows");
   });
 });
 


### PR DESCRIPTION
Avoid hydrating the shared `site.top_tags` payload in the sidebar block,
since the native `TagDrop` reads that same raw data for its menu. Render
popular tags from the serialized tag data directly so the sidebar no
longer interferes with the header tag dropdown.

c.f. https://meta.discourse.org/t/tags-block-is-conflicting-with-other-tag-dropdowns/404723

**Before**

<img width="1101" height="254" alt="image" src="https://github.com/user-attachments/assets/60af56e2-aafd-4ad0-9bed-abc6807334bc" />

**After**

<img width="1112" height="322" alt="image" src="https://github.com/user-attachments/assets/7ec35981-d833-4b1e-839f-c4cb5f0db378" />
